### PR TITLE
Rdp connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This document provides a list of notable changes introduced in the Wayk Client PowerShell module.
 
+## 2020.3.2 (2021-02-02)
+  * Add initial support for Wayk RDP remoting.
+
 ## 2020.3.1 (2020-11-30)
   * Add initial support for Wayk PowerShell remoting.
  

--- a/WaykClient/Public/WaykClientSession.ps1
+++ b/WaykClient/Public/WaykClientSession.ps1
@@ -161,8 +161,10 @@ function Connect-WaykRdpTcpSession
     if ($IsWindows) {
         $RdpConfigFile = New-TemporaryFile
         "$RdpConfig" | Out-File -FilePath "$RdpConfigFile"
-        Invoke-Expression "mstsc ${RdpConfigFile}"
+        Start-Process -FilePath "mstsc" -ArgumentList "${RdpConfigFile}"
     } else {
-        Invoke-Expression "xfreerdp ${RdpConfig}"
+        # -Wait flag is required here to block PowerShell command parsing from
+        # stdin while xfreerdp asks for credentials
+        Start-Process -FilePath "xfreerdp" -Wait -ArgumentList "${RdpConfig}"
     }
 }

--- a/WaykClient/Public/WaykClientSession.ps1
+++ b/WaykClient/Public/WaykClientSession.ps1
@@ -157,15 +157,12 @@ function Connect-WaykRdpTcpSession
     }
 
     $RdpConfig = $CommandOutput.RdpConfig = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($CommandOutput.RdpConfig))
-    $RdpConfigFile = New-TemporaryFile
-
-    "$RdpConfig" | Out-File -FilePath "$RdpConfigFile"
 
     if ($IsWindows) {
-        $RdpApp = "mstsc"
+        $RdpConfigFile = New-TemporaryFile
+        "$RdpConfig" | Out-File -FilePath "$RdpConfigFile"
+        Invoke-Expression "mstsc ${RdpConfigFile}"
     } else {
-        $RdpApp = "xfreerdp"
+        Invoke-Expression "xfreerdp ${RdpConfig}"
     }
-
-    & $RdpApp "$RdpConfigFile"
 }

--- a/WaykClient/Public/WaykClientSession.ps1
+++ b/WaykClient/Public/WaykClientSession.ps1
@@ -213,7 +213,7 @@ function Enter-WaykRdpSession
 
     if ($IsWindows) {
         $RdpApp = "mstsc"
-        Start-Process -FilePath:$RdpApp -ArgumentList:$RdpConfigFile
+        Start-Process -FilePath:$RdpApp -ArgumentList:$RdpArgs
     } else {
         $RdpApp = "xfreerdp"
         $RdpArgs += "/sec:nla"
@@ -225,8 +225,9 @@ function Enter-WaykRdpSession
         if ($Domain) {
             $RdpArgs += "/d:${Domain}"
         }
-        Start-Process -FilePath:$RdpApp -ArgumentList:$RdpConfigFile -Wait
+        
+        
+        Start-Process -FilePath:$RdpApp -ArgumentList:$RdpArgs -Wait
     }
 }
-
 

--- a/WaykClient/Public/WaykClientSession.ps1
+++ b/WaykClient/Public/WaykClientSession.ps1
@@ -73,7 +73,6 @@ function Connect-WaykPSSession
     $WaykClient = Get-WaykClientCommand
 
     $CommandInput = [PSCustomObject]@{
-        Type = "start_pwsh_session"
         Hostname = $HostName
         Username = $UserName
         Password = $Password
@@ -129,18 +128,40 @@ function Enter-WaykPSSession
     Exit-WaykPSEnvironment
 }
 
-function Connect-WaykRdpTcpSession
+function DecodeBase64UrlSafe($Base64Url)
+{
+    # short circuit on empty strings
+    if ($Base64Url -eq [string]::Empty) {
+        return [string]::Empty
+    }
+
+    # put the standard unsafe characters back
+    $s = $Base64Url.Replace('-', '+').Replace('_', '/')
+
+    # put the padding back
+    switch ($s.Length % 4) {
+        0 { break; }             # no padding needed
+        2 { $s += '=='; break; } # two pad chars
+        3 { $s += '='; break; }  # one pad char
+        default { throw "Invalid Base64Url string" }
+    }
+
+    return [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($s))
+}
+
+function Connect-WaykRdpSession
 {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory=$true)]
-        [String] $HostName
+        [String] $HostName,
+        [String] $TransportProtocol = "tcp",
+        [String] $RdpOutputFile
     )
 
     $WaykClient = Get-WaykClientCommand
 
     $CommandInput = [PSCustomObject]@{
-        Type = "start_rdp_tcp_session"
         Hostname = $HostName
     } | ConvertTo-Json -Compress | Out-String
 
@@ -156,15 +177,56 @@ function Connect-WaykRdpTcpSession
         throw "Failed to connect to ${HostName} with error $($CommandOutput.Error)"
     }
 
-    $RdpConfig = $CommandOutput.RdpConfig = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($CommandOutput.RdpConfig))
+    $RdpConfig = DecodeBase64UrlSafe($CommandOutput.RdpConfig)
+
+    if ($RdpOutputFile) {
+        $RdpConfig | Out-File -FilePath $RdpOutputFile
+        return
+    }
+
+    return $RdpConfig
+}
+
+function Enter-WaykRdpSession
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory=$true)]
+        [String] $HostName,
+        [String] $TransportProtocol = "tcp",
+        [String] $UserName,
+        [String] $Domain
+    )
+
+    if ($IsWindows -And ($UserName -Or $Domain)) {
+        # There is no simple way to specify user name and domain to the mstsc,
+        # they are only can be stored on the machine globally for the specified
+        # hostname using cmdkey command, which may leave a trace on the machine
+        throw "-UserName/-Domain arguements are not supported on the Windows platform"
+    }
+
+    $RdpConfigFile = $(New-TemporaryFile) -Replace ".tmp", ".rdp"
+
+    Connect-WaykRdpSession -HostName:$HostName -TransportProtocol:$TransportProtocol -RdpOutputFile:$RdpConfigFile
+
+    $RdpArgs = @("${RdpConfigFile}")
 
     if ($IsWindows) {
-        $RdpConfigFile = New-TemporaryFile
-        "$RdpConfig" | Out-File -FilePath "$RdpConfigFile"
-        Start-Process -FilePath "mstsc" -ArgumentList "${RdpConfigFile}"
+        $RdpApp = "mstsc"
+        Start-Process -FilePath:$RdpApp -ArgumentList:$RdpConfigFile
     } else {
-        # -Wait flag is required here to block PowerShell command parsing from
-        # stdin while xfreerdp asks for credentials
-        Start-Process -FilePath "xfreerdp" -Wait -ArgumentList "${RdpConfig}"
+        $RdpApp = "xfreerdp"
+        $RdpArgs += "/sec:nla"
+        $RdpArgs += "/cert-ignore"
+        $RdpArgs += "/from-stdin"
+        if ($UserName) {
+            $RdpArgs += "/u:${UserName}"
+        }
+        if ($Domain) {
+            $RdpArgs += "/d:${Domain}"
+        }
+        Start-Process -FilePath:$RdpApp -ArgumentList:$RdpConfigFile -Wait
     }
 }
+
+

--- a/WaykClient/WaykClient.psd1
+++ b/WaykClient/WaykClient.psd1
@@ -12,7 +12,7 @@
 RootModule = 'WaykClient.psm1'
 
 # Version number of this module.
-ModuleVersion = '2020.3.1'
+ModuleVersion = '2020.3.2'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'
@@ -73,7 +73,8 @@ FunctionsToExport = @('Get-WaykClientVersion', 'Get-WaykClientPackage',
     'Install-WaykClient', 'Uninstall-WaykClient', 'Update-WaykClient',
     'Start-WaykClient', 'Stop-WaykClient', 'Restart-WaykClient', 'Get-WaykClientCommand',
     'Set-WaykClientConfig', 'Get-WaykClientPath', 'Get-WaykClientConfig',
-    'Connect-WaykPSSession', 'New-WaykPSSession', 'Enter-WaykPSSession')
+    'Connect-WaykPSSession', 'New-WaykPSSession', 'Enter-WaykPSSession',
+    'Connect-WaykRdpTcpSession')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()
@@ -114,7 +115,7 @@ PrivateData = @{
         # ReleaseNotes = ''
 
         # Prerelease string of this module
-        #Prerelease = 'rc1'
+        Prerelease = 'rc1'
 
     } # End of PSData hashtable
 

--- a/WaykClient/WaykClient.psd1
+++ b/WaykClient/WaykClient.psd1
@@ -74,7 +74,7 @@ FunctionsToExport = @('Get-WaykClientVersion', 'Get-WaykClientPackage',
     'Start-WaykClient', 'Stop-WaykClient', 'Restart-WaykClient', 'Get-WaykClientCommand',
     'Set-WaykClientConfig', 'Get-WaykClientPath', 'Get-WaykClientConfig',
     'Connect-WaykPSSession', 'New-WaykPSSession', 'Enter-WaykPSSession',
-    'Connect-WaykRdpTcpSession')
+    'Connect-WaykRdpSession', 'Enter-WaykRdpSession')
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()


### PR DESCRIPTION
This token adds RDP connectivity support to the WaykClient-ps module. New "Connect-WaykRdpTcpSession" function communicates with WaykClient executable to start RDP session and receives target RDP client application config/arguments which are used to start it. 