### PR TITLE
Public/WaykClientSession.ps1: Use generic RE to match tmp file extension

### DIFF
--- a/WaykClient/Public/WaykClientSession.ps1
+++ b/WaykClient/Public/WaykClientSession.ps1
@@ -210,7 +210,7 @@ function Enter-WaykRdpSession
         throw "-UserName/-Domain arguements are not supported on the Windows platform"
     }
 
-    $RdpConfigFile = $(New-TemporaryFile) -Replace ".tmp", ".rdp"
+    $RdpConfigFile = $(New-TemporaryFile) -Replace "[.][^.]+$", ".rdp"
 
     Connect-WaykRdpSession -HostName:$HostName -TransportProtocol:$TransportProtocol -RdpOutputFile:$RdpConfigFile
 


### PR DESCRIPTION
The current implementation generates the temporary file used by an rdp session using the New-TemporaryFile cmdlet and replacing the '.tmp' extension with '.rdp'.
    
However, on Windows, this results in an invalid file path being generated. E.g. %USERPROFILE%\AppData\Local\Temp.rdp2F86.rdp, due to the replacement pattern being applied to all matching occurences found.
On Linux, the problem does not manifest itself, because the temporary file is created in the current working directory as a dot file.
    
The current implementation uses a tmp string literal preceeded by any other character in the RE operand to the replace operator to match the extension of the tmp file being generated. Although this works, the pattern would also match files that end in 'any character' followed by tmp, such as atmp, etc. Use a generic RE that matches any file extension represented by a literal dot followed by one or more non-dot characters