### PR TITLE
Improve Enter-WaykSshSession cmdlet

### DIFF
--- a/WaykClient/WaykClient.psd1
+++ b/WaykClient/WaykClient.psd1
@@ -115,7 +115,7 @@ PrivateData = @{
         # ReleaseNotes = ''
 
         # Prerelease string of this module
-        Prerelease = 'rc1'
+        Prerelease = 'rc2'
 
     } # End of PSData hashtable
 


### PR DESCRIPTION
Find a random port to use for the local jetsocat proxy instead of
hardcoding one.
A small sleep time is also added after jetsocat spawn because there is a race
condition between jetsocat startup and ssh command.